### PR TITLE
Dropping pagmo make_unique and update to test output

### DIFF
--- a/pygmo/_island_test.py
+++ b/pygmo/_island_test.py
@@ -309,7 +309,10 @@ class island_test_case(_ut.TestCase):
         isl = island(algo=de(), prob=rosenbrock(), size=25)
         self.assertTrue(repr(isl) != "")
         self.assertTrue(isl.get_name() == "Thread island")
-        self.assertTrue(isl.get_extra_info() == "\tUsing pool: yes")
+        if _pagmo_version_major < 3 or (_pagmo_version_major == 3 and _pagmo_version_minor < 16):
+            self.assertTrue(isl.get_extra_info() == "")
+        else:
+            self.assertTrue(isl.get_extra_info() == "\tUsing pool: yes")
         isl = island(algo=de(), prob=rosenbrock(), size=25, udi=_udi_01())
         self.assertTrue(repr(isl) != "")
         self.assertTrue(isl.get_name() == "udi_01")

--- a/pygmo/_island_test.py
+++ b/pygmo/_island_test.py
@@ -309,7 +309,7 @@ class island_test_case(_ut.TestCase):
         isl = island(algo=de(), prob=rosenbrock(), size=25)
         self.assertTrue(repr(isl) != "")
         self.assertTrue(isl.get_name() == "Thread island")
-        if _pagmo_version_major < 3 or (_pagmo_version_major == 3 and _pagmo_version_minor < 16):
+        if _pagmo_version_major < 2 or (_pagmo_version_major == 2 and _pagmo_version_minor < 16):
             self.assertTrue(isl.get_extra_info() == "")
         else:
             self.assertTrue(isl.get_extra_info() == "\tUsing pool: yes")

--- a/pygmo/_island_test.py
+++ b/pygmo/_island_test.py
@@ -309,7 +309,7 @@ class island_test_case(_ut.TestCase):
         isl = island(algo=de(), prob=rosenbrock(), size=25)
         self.assertTrue(repr(isl) != "")
         self.assertTrue(isl.get_name() == "Thread island")
-        self.assertTrue(isl.get_extra_info() == "")
+        self.assertTrue(isl.get_extra_info() == "\tUsing pool: yes")
         isl = island(algo=de(), prob=rosenbrock(), size=25, udi=_udi_01())
         self.assertTrue(repr(isl) != "")
         self.assertTrue(isl.get_name() == "udi_01")

--- a/pygmo/_island_test.py
+++ b/pygmo/_island_test.py
@@ -305,7 +305,7 @@ class island_test_case(_ut.TestCase):
         isl.wait()
 
     def run_io_tests(self):
-        from .core import island, de, rosenbrock
+        from .core import island, de, rosenbrock, _pagmo_version_major, _pagmo_version_minor
         isl = island(algo=de(), prob=rosenbrock(), size=25)
         self.assertTrue(repr(isl) != "")
         self.assertTrue(isl.get_name() == "Thread island")

--- a/pygmo/algorithm.cpp
+++ b/pygmo/algorithm.cpp
@@ -18,7 +18,6 @@
 #include <pybind11/pybind11.h>
 
 #include <pagmo/config.hpp>
-#include <pagmo/detail/make_unique.hpp>
 #include <pagmo/population.hpp>
 #include <pagmo/s11n.hpp>
 #include <pagmo/threading.hpp>
@@ -61,7 +60,7 @@ algo_inner<py::object>::algo_inner(const py::object &o)
 std::unique_ptr<algo_inner_base> algo_inner<py::object>::clone() const
 {
     // This will make a deep copy using the ctor above.
-    return detail::make_unique<algo_inner>(m_value);
+    return std::make_unique<algo_inner>(m_value);
 }
 
 population algo_inner<py::object>::evolve(const population &pop) const

--- a/pygmo/bfe.cpp
+++ b/pygmo/bfe.cpp
@@ -19,7 +19,6 @@
 #include <pybind11/pybind11.h>
 
 #include <pagmo/config.hpp>
-#include <pagmo/detail/make_unique.hpp>
 #include <pagmo/problem.hpp>
 #include <pagmo/s11n.hpp>
 #include <pagmo/threading.hpp>
@@ -62,7 +61,7 @@ bfe_inner<py::object>::bfe_inner(const py::object &o)
 std::unique_ptr<bfe_inner_base> bfe_inner<py::object>::clone() const
 {
     // This will make a deep copy using the ctor above.
-    return detail::make_unique<bfe_inner>(m_value);
+    return std::make_unique<bfe_inner>(m_value);
 }
 
 vector_double bfe_inner<py::object>::operator()(const problem &p, const vector_double &dvs) const

--- a/pygmo/core.cpp
+++ b/pygmo/core.cpp
@@ -28,7 +28,6 @@
 #include <pagmo/bfe.hpp>
 #include <pagmo/config.hpp>
 #include <pagmo/detail/gte_getter.hpp>
-#include <pagmo/detail/make_unique.hpp>
 #include <pagmo/exceptions.hpp>
 #include <pagmo/island.hpp>
 #include <pagmo/islands/thread_island.hpp>
@@ -252,7 +251,7 @@ PYBIND11_MODULE(core, m)
               if (algo.get_thread_safety() >= pg::thread_safety::basic
                   && pop.get_problem().get_thread_safety() >= pg::thread_safety::basic) {
                   // Both algo and prob have at least the basic thread safety guarantee. Use the thread island.
-                  ptr = pg::detail::make_unique<pg::detail::isl_inner<pg::thread_island>>();
+                  ptr = std::make_unique<pg::detail::isl_inner<pg::thread_island>>();
               } else {
                   // NOTE: here we are re-implementing a piece of code that normally
                   // is pure C++. We are calling into the Python interpreter, so, in order to handle
@@ -262,7 +261,7 @@ PYBIND11_MODULE(core, m)
                   // it we use the ensurer.
                   pygmo::gil_thread_ensurer gte;
                   auto py_island = py::module::import("pygmo").attr("mp_island");
-                  ptr = pg::detail::make_unique<pg::detail::isl_inner<py::object>>(py_island());
+                  ptr = std::make_unique<pg::detail::isl_inner<py::object>>(py_island());
               }
           };
 
@@ -362,11 +361,11 @@ PYBIND11_MODULE(core, m)
     py::class_<pg::hypervolume> hv_class(m, "hypervolume", "Hypervolume Class");
     hv_class
         .def(py::init([](const py::array_t<double> &points) {
-                 return pg::detail::make_unique<pg::hypervolume>(
+                 return std::make_unique<pg::hypervolume>(
                      pygmo::ndarr_to_vvector<std::vector<pg::vector_double>>(points), true);
              }),
              py::arg("points"), pygmo::hv_init2_docstring().c_str())
-        .def(py::init([](const pg::population &pop) { return pg::detail::make_unique<pg::hypervolume>(pop, true); }),
+        .def(py::init([](const pg::population &pop) { return std::make_unique<pg::hypervolume>(pop, true); }),
              py::arg("pop"), pygmo::hv_init1_docstring().c_str())
         .def(
             "compute",

--- a/pygmo/expose_problems_0.cpp
+++ b/pygmo/expose_problems_0.cpp
@@ -13,7 +13,6 @@
 #include <pybind11/pybind11.h>
 
 #include <pagmo/config.hpp>
-#include <pagmo/detail/make_unique.hpp>
 #include <pagmo/population.hpp>
 #include <pagmo/problem.hpp>
 #include <pagmo/problems/ackley.hpp>
@@ -129,7 +128,7 @@ void expose_problems_0(py::module &m, py::class_<pagmo::problem> &prob, py::modu
         // and then invoke this ctor. This way we avoid having to expose a different ctor for every exposed C++ prob.
         .def(py::init([](const pagmo::problem &p, const py::array_t<double> &weight, const py::array_t<double> &z,
                          const std::string &method, bool adapt_ideal) {
-            return pagmo::detail::make_unique<pagmo::decompose>(p, pygmo::ndarr_to_vector<pagmo::vector_double>(weight),
+            return std::make_unique<pagmo::decompose>(p, pygmo::ndarr_to_vector<pagmo::vector_double>(weight),
                                                                 pygmo::ndarr_to_vector<pagmo::vector_double>(z), method,
                                                                 adapt_ideal);
         }))

--- a/pygmo/expose_problems_0.cpp
+++ b/pygmo/expose_problems_0.cpp
@@ -6,6 +6,7 @@
 // Public License v. 2.0. If a copy of the MPL was not distributed
 // with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#include <memory>
 #include <string>
 #include <utility>
 
@@ -129,16 +130,15 @@ void expose_problems_0(py::module &m, py::class_<pagmo::problem> &prob, py::modu
         .def(py::init([](const pagmo::problem &p, const py::array_t<double> &weight, const py::array_t<double> &z,
                          const std::string &method, bool adapt_ideal) {
             return std::make_unique<pagmo::decompose>(p, pygmo::ndarr_to_vector<pagmo::vector_double>(weight),
-                                                                pygmo::ndarr_to_vector<pagmo::vector_double>(z), method,
-                                                                adapt_ideal);
+                                                      pygmo::ndarr_to_vector<pagmo::vector_double>(z), method,
+                                                      adapt_ideal);
         }))
-        .def(
-            "original_fitness",
-            [](const pagmo::decompose &p, const py::array_t<double> &x) {
-                return pygmo::vector_to_ndarr<py::array_t<double>>(
-                    p.original_fitness(pygmo::ndarr_to_vector<pagmo::vector_double>(x)));
-            },
-            decompose_original_fitness_docstring().c_str(), py::arg("x"))
+        .def("original_fitness",
+             [](const pagmo::decompose &p, const py::array_t<double> &x) {
+                 return pygmo::vector_to_ndarr<py::array_t<double>>(
+                     p.original_fitness(pygmo::ndarr_to_vector<pagmo::vector_double>(x)));
+             },
+             decompose_original_fitness_docstring().c_str(), py::arg("x"))
         .def_property_readonly(
             "z", [](const pagmo::decompose &p) { return pygmo::vector_to_ndarr<py::array_t<double>>(p.get_z()); },
             decompose_z_docstring().c_str())
@@ -175,9 +175,8 @@ void expose_problems_0(py::module &m, py::class_<pagmo::problem> &prob, py::modu
     dtlz_p.def("p_distance", [](const pagmo::dtlz &z, const py::array_t<double> &x) {
         return z.p_distance(ndarr_to_vector<pagmo::vector_double>(x));
     });
-    dtlz_p.def(
-        "p_distance", [](const pagmo::dtlz &z, const pagmo::population &pop) { return z.p_distance(pop); },
-        dtlz_p_distance_docstring().c_str());
+    dtlz_p.def("p_distance", [](const pagmo::dtlz &z, const pagmo::population &pop) { return z.p_distance(pop); },
+               dtlz_p_distance_docstring().c_str());
 
     // CEC 2006
     auto cec2006_ = expose_problem<pagmo::cec2006>(m, prob, p_module, "cec2006", cec2006_docstring().c_str());

--- a/pygmo/expose_problems_1.cpp
+++ b/pygmo/expose_problems_1.cpp
@@ -7,12 +7,12 @@
 // with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include <string>
+#include <memory>
 
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 
 #include <pagmo/config.hpp>
-#include <pagmo/detail/make_unique.hpp>
 #include <pagmo/population.hpp>
 #include <pagmo/problem.hpp>
 #include <pagmo/problems/golomb_ruler.hpp>
@@ -53,7 +53,7 @@ void expose_problems_1(py::module &m, py::class_<pagmo::problem> &prob, py::modu
         // NOTE: An __init__ wrapper on the Python side will take care of cting a pagmo::problem from the input UDP,
         // and then invoke this ctor. This way we avoid having to expose a different ctor for every exposed C++ prob.
         .def(py::init([](const pagmo::problem &p, const py::array_t<double> &tv) {
-            return pagmo::detail::make_unique<pagmo::translate>(p, pygmo::ndarr_to_vector<pagmo::vector_double>(tv));
+            return std::make_unique<pagmo::translate>(p, pygmo::ndarr_to_vector<pagmo::vector_double>(tv));
         }))
         .def_property_readonly(
             "translation",
@@ -117,7 +117,7 @@ void expose_problems_1(py::module &m, py::class_<pagmo::problem> &prob, py::modu
     // and then invoke this ctor. This way we avoid having to expose a different ctor for every exposed C++ prob.
     unconstrain_
         .def(py::init([](const pagmo::problem &p, const std::string &method, const py::array_t<double> &weights) {
-            return pagmo::detail::make_unique<pagmo::unconstrain>(p, method,
+            return std::make_unique<pagmo::unconstrain>(p, method,
                                                                   ndarr_to_vector<pagmo::vector_double>(weights));
         }))
         .def_property_readonly(

--- a/pygmo/expose_topologies.cpp
+++ b/pygmo/expose_topologies.cpp
@@ -13,7 +13,6 @@
 #include <pybind11/pybind11.h>
 
 #include <pagmo/config.hpp>
-#include <pagmo/detail/make_unique.hpp>
 #include <pagmo/topologies/fully_connected.hpp>
 #include <pagmo/topologies/ring.hpp>
 #include <pagmo/topologies/unconnected.hpp>
@@ -113,7 +112,7 @@ void expose_topologies(py::module &m, py::class_<pagmo::topology> &topo, py::mod
     // Free-form.
     auto free_form_ = expose_topology<pagmo::free_form>(m, topo, t_module, "free_form", free_form_docstring().c_str());
     free_form_.def(py::init<const pagmo::topology &>()).def(py::init([](const py::object &o) {
-        return pagmo::detail::make_unique<pagmo::free_form>(networkx_to_bgl_graph_t(o));
+        return std::make_unique<pagmo::free_form>(networkx_to_bgl_graph_t(o));
     }));
     detail::expose_base_bgl_topo(free_form_);
 #endif

--- a/pygmo/expose_topologies.cpp
+++ b/pygmo/expose_topologies.cpp
@@ -7,6 +7,7 @@
 // with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include <cstddef>
+#include <memory>
 #include <utility>
 #include <vector>
 

--- a/pygmo/island.cpp
+++ b/pygmo/island.cpp
@@ -19,7 +19,6 @@
 
 #include <pagmo/algorithm.hpp>
 #include <pagmo/config.hpp>
-#include <pagmo/detail/make_unique.hpp>
 #include <pagmo/island.hpp>
 #include <pagmo/population.hpp>
 #include <pagmo/s11n.hpp>
@@ -53,7 +52,7 @@ isl_inner<py::object>::isl_inner(const py::object &o)
 std::unique_ptr<isl_inner_base> isl_inner<py::object>::clone() const
 {
     // This will make a deep copy using the ctor above.
-    return detail::make_unique<isl_inner>(m_value);
+    return std::make_unique<isl_inner>(m_value);
 }
 
 void isl_inner<py::object>::run_evolve(island &isl) const

--- a/pygmo/problem.cpp
+++ b/pygmo/problem.cpp
@@ -22,7 +22,6 @@
 #include <pybind11/pybind11.h>
 
 #include <pagmo/config.hpp>
-#include <pagmo/detail/make_unique.hpp>
 #include <pagmo/problem.hpp>
 #include <pagmo/s11n.hpp>
 #include <pagmo/threading.hpp>
@@ -69,7 +68,7 @@ prob_inner<py::object>::prob_inner(const py::object &o)
 std::unique_ptr<prob_inner_base> prob_inner<py::object>::clone() const
 {
     // This will make a deep copy using the ctor above.
-    return detail::make_unique<prob_inner>(m_value);
+    return std::make_unique<prob_inner>(m_value);
 }
 
 vector_double prob_inner<py::object>::fitness(const vector_double &dv) const

--- a/pygmo/r_policy.cpp
+++ b/pygmo/r_policy.cpp
@@ -19,7 +19,6 @@
 #include <pybind11/pybind11.h>
 
 #include <pagmo/config.hpp>
-#include <pagmo/detail/make_unique.hpp>
 #include <pagmo/r_policy.hpp>
 #include <pagmo/s11n.hpp>
 #include <pagmo/types.hpp>
@@ -62,7 +61,7 @@ r_pol_inner<py::object>::r_pol_inner(const py::object &o)
 std::unique_ptr<r_pol_inner_base> r_pol_inner<py::object>::clone() const
 {
     // This will make a deep copy using the ctor above.
-    return detail::make_unique<r_pol_inner>(m_value);
+    return std::make_unique<r_pol_inner>(m_value);
 }
 
 individuals_group_t

--- a/pygmo/s_policy.cpp
+++ b/pygmo/s_policy.cpp
@@ -19,7 +19,6 @@
 #include <pybind11/pybind11.h>
 
 #include <pagmo/config.hpp>
-#include <pagmo/detail/make_unique.hpp>
 #include <pagmo/s11n.hpp>
 #include <pagmo/s_policy.hpp>
 #include <pagmo/types.hpp>
@@ -62,7 +61,7 @@ s_pol_inner<py::object>::s_pol_inner(const py::object &o)
 std::unique_ptr<s_pol_inner_base> s_pol_inner<py::object>::clone() const
 {
     // This will make a deep copy using the ctor above.
-    return detail::make_unique<s_pol_inner>(m_value);
+    return std::make_unique<s_pol_inner>(m_value);
 }
 
 individuals_group_t s_pol_inner<py::object>::select(const individuals_group_t &inds, const vector_double::size_type &nx,

--- a/pygmo/sr_policy_add_rate_constructor.hpp
+++ b/pygmo/sr_policy_add_rate_constructor.hpp
@@ -13,8 +13,6 @@
 
 #include <pybind11/pybind11.h>
 
-#include <pagmo/detail/make_unique.hpp>
-
 #include "common_utils.hpp"
 
 namespace pygmo
@@ -32,9 +30,9 @@ inline void sr_policy_add_rate_constructor(py::class_<Pol> &c)
 {
     c.def(py::init([](const py::object &o) -> std::unique_ptr<Pol> {
               if (py::isinstance(o, builtins().attr("int"))) {
-                  return pagmo::detail::make_unique<Pol>(py::cast<int>(o));
+                  return std::make_unique<Pol>(py::cast<int>(o));
               } else if (py::isinstance(o, builtins().attr("float"))) {
-                  return pagmo::detail::make_unique<Pol>(py::cast<double>(o));
+                  return std::make_unique<Pol>(py::cast<double>(o));
               } else {
                   py_throw(PyExc_TypeError,
                            ("cannot construct a replacement/selection policy from a migration rate of type '"

--- a/pygmo/topology.cpp
+++ b/pygmo/topology.cpp
@@ -65,7 +65,7 @@ topo_inner<py::object>::topo_inner(const py::object &o)
 std::unique_ptr<topo_inner_base> topo_inner<py::object>::clone() const
 {
     // This will make a deep copy using the ctor above.
-    return detail::make_unique<topo_inner>(m_value);
+    return std::make_unique<topo_inner>(m_value);
 }
 
 std::pair<std::vector<std::size_t>, vector_double> topo_inner<py::object>::get_connections(std::size_t n) const


### PR DESCRIPTION
The CI on this will fail as long as https://github.com/esa/pagmo2/pull/409 is not merged.

The PR fixes incompatibilities with the removal of detail::make_unique and the change in the island text representation (no longer empty)