### PR TITLE
fix dill for mac/windows builds

### DIFF
--- a/tools/gha_macos-10.15-py310.sh
+++ b/tools/gha_macos-10.15-py310.sh
@@ -13,7 +13,7 @@ export PATH="$HOME/miniconda/bin:$PATH"
 bash miniconda.sh -b -p $HOME/miniconda
 conda config --add channels conda-forge
 conda config --set channel_priority strict
-conda create -y -q -p $deps_dir c-compiler cxx-compiler cmake eigen nlopt ipopt boost-cpp tbb tbb-devel python=3.10 numpy cloudpickle networkx dill numba pybind11 sphinx myst-nb sphinx-book-theme scipy
+conda create -y -q -p $deps_dir c-compiler cxx-compiler cmake eigen nlopt ipopt boost-cpp tbb tbb-devel python=3.10 numpy cloudpickle networkx dill=0.3.5.1 numba pybind11 sphinx myst-nb sphinx-book-theme scipy
 source activate $deps_dir
 
 # Install pagmo.

--- a/tools/gha_macos-10.15-py38.sh
+++ b/tools/gha_macos-10.15-py38.sh
@@ -13,7 +13,7 @@ export PATH="$HOME/miniconda/bin:$PATH"
 bash miniconda.sh -b -p $HOME/miniconda
 conda config --add channels conda-forge
 conda config --set channel_priority strict
-conda create -y -q -p $deps_dir c-compiler cxx-compiler cmake eigen nlopt ipopt boost-cpp tbb tbb-devel python=3.8 numpy cloudpickle networkx dill numba pybind11 sphinx myst-nb sphinx-book-theme scipy
+conda create -y -q -p $deps_dir c-compiler cxx-compiler cmake eigen nlopt ipopt boost-cpp tbb tbb-devel python=3.8 numpy cloudpickle networkx dill=0.3.5.1 numba pybind11 sphinx myst-nb sphinx-book-theme scipy
 source activate $deps_dir
 
 # Install pagmo.

--- a/tools/gha_macos-10.15-py39.sh
+++ b/tools/gha_macos-10.15-py39.sh
@@ -13,7 +13,7 @@ export PATH="$HOME/miniconda/bin:$PATH"
 bash miniconda.sh -b -p $HOME/miniconda
 conda config --add channels conda-forge
 conda config --set channel_priority strict
-conda create -y -q -p $deps_dir c-compiler cxx-compiler cmake eigen nlopt ipopt boost-cpp tbb tbb-devel python=3.9 numpy cloudpickle networkx dill numba pybind11 sphinx myst-nb sphinx-book-theme scipy
+conda create -y -q -p $deps_dir c-compiler cxx-compiler cmake eigen nlopt ipopt boost-cpp tbb tbb-devel python=3.9 numpy cloudpickle networkx dill=0.3.5.1 numba pybind11 sphinx myst-nb sphinx-book-theme scipy
 source activate $deps_dir
 
 # Install pagmo.

--- a/tools/gha_windows.ps1
+++ b/tools/gha_windows.ps1
@@ -2,7 +2,7 @@
 # Powershell script
 # Install conda environment
 conda config --set always_yes yes
-conda create --name pygmo cmake eigen nlopt ipopt boost-cpp tbb tbb-devel numpy cloudpickle networkx dill numba pybind11 scipy
+conda create --name pygmo cmake eigen nlopt ipopt boost-cpp tbb tbb-devel numpy cloudpickle networkx dill=0.3.5.1 numba pybind11 scipy
 conda activate pygmo
 
 # Install pagmo.


### PR DESCRIPTION
didn't see the files in `tools/` for the mac and windows builds so i'm updating those to require `dill=0.3.5.1` to see if those fix the CI builds