### PR TITLE
Fix typos in the tutorials

### DIFF
--- a/doc/tutorials/coding_udi.rst
+++ b/doc/tutorials/coding_udi.rst
@@ -24,7 +24,7 @@ the :class:`~pygmo.population` ``pop``.
     ...     def get_name(self):
     ...         return "It's my island!"
 
-We have also included above the optional method ``get_name(self)`` that will be used by various ``__repr__(self)`` to provide humar readable information
+We have also included above the optional method ``get_name(self)`` that will be used by various ``__repr__(self)`` to provide human readable information
 on some pygmo classes. The above UDI can then be used to construct a :class:`~pygmo.island` (similarly to how UDP can be used to construct :class:`~pygmo.problem`, etc..).
 
 .. doctest::

--- a/doc/tutorials/coding_udp_constrained.rst
+++ b/doc/tutorials/coding_udp_constrained.rst
@@ -43,7 +43,7 @@ Neglecting for the time being the fitness, the basic structure for the UDP to ha
 
 Note how we need to specify both the number of equality constraints and the number of inequality constraints (as pygmo by default assumes
 0 for both). There is no need to specify the number of objectives as by default pygmo assumes single objective optimization.
-The full documenation on the UDP specification can be found in the :class:`pygmo.problem` docs.
+The full documentation on the UDP specification can be found in the :class:`pygmo.problem` docs.
 
 We still have to write the fitness function as that is a mandatory method (together with ``get_bounds()``) for all UDPs. Constructing a :class:`~pygmo.problem` with
 an incomplete UDP will fail. In pygmo the fitness includes both the objectives and the constraints according to the described order [obj,ec,ic]. All equality constraints
@@ -109,7 +109,7 @@ All seems in order. The dimensions are corresponding to what we wanted, the grad
 Solving your constrained UDP
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-So we now have a UDP with constraints and a numerical gradient. Let's solve it. Many different startegies can be deployed
+So we now have a UDP with constraints and a numerical gradient. Let's solve it. Many different strategies can be deployed
 and we here will just try two a) using the augmented lagrangian method b) using monotonic basin hopping.
 Consider the following script:
 

--- a/doc/tutorials/coding_udp_minlp.rst
+++ b/doc/tutorials/coding_udp_minlp.rst
@@ -44,7 +44,7 @@ Neglecting, for the time being the fitness, the basic structure for the UDP to h
 Note how we need to specify explicitly the number of inequality constraints and the integer problem
 dimension (as pygmo otherwise by default assumes 0 for both). Note also that the bounds (for the integer part)
 must be integers, otherwise pygmo will complain. There is no need, for this case, to also specify explicitly the number of objectives
-as by default pygmo assumes single objective optimization. The full documenation on the UDP optional methods can be
+as by default pygmo assumes single objective optimization. The full documentation on the UDP optional methods can be
 found in the :class:`pygmo.problem` docs.
 
 We still have to write the fitness function, as that is a mandatory method (together with ``get_bounds()``) for all UDPs. Constructing a :class:`~pygmo.problem` with
@@ -172,6 +172,6 @@ We found a feasible solution! Note that in the other 3 cases no feasible solutio
 
 .. note::
    The solution strategy above is, in general, flawed in assuming the best solution of the relaxed problem is close to the
-   the full MINLP problem solution. More sophisticated techniques would instead search the combinatorial part more exhaustvely.
+   the full MINLP problem solution. More sophisticated techniques would instead search the combinatorial part more exhaustively.
    We used here this approach only to show how simple is, in pygmo, to define and solve the relaxed problem and
    to then feedback the optimal decision vector into a MINLP solution strategy. 


### PR DESCRIPTION
Fix some typos in the tutorials documentation.