### PR TITLE
Fixed tutorial bug.

### DIFF
--- a/doc/tutorials/coding_udp_simple.rst
+++ b/doc/tutorials/coding_udp_simple.rst
@@ -229,8 +229,10 @@ our fitness method into C code.
     >>> class jit_rosenbrock:
     ...     def __init__(self,dim):
     ...         self.dim = dim
-    ...     @jit
     ...     def fitness(self,x):
+    ...         return jit_rosenbrock._fitness(x)
+    ...     @jit
+    ...     def _fitness(x):
     ...         retval = np.zeros((1,))
     ...         for i in range(len(x) - 1):
     ...             retval[0] += 100.*(x[i + 1]-x[i]**2)**2+(1.-x[i])**2


### PR DESCRIPTION
I was going through the tutorial titled "Coding a simple User Defined Problem" and ran into one error.

The issue seems to be that the jit decorator cannot be applied to classes for the time being.

The fix is simple and is present in the subsequent iteration of the problem (jit_rosenbrock2): applying the jit decorator to a static method (_fitness) that is then called by the class method (fitness).

I tested this by creating the docs myself. Unfortunately, the information for this is a bit lacking and required some tweaking. Perhaps this is something that can be improved.