### PR TITLE
test: skip tests when optional dependencies are not installed #120

### DIFF
--- a/pygmo/_algorithm_test.py
+++ b/pygmo/_algorithm_test.py
@@ -25,7 +25,6 @@ class algorithm_test_case(_ut.TestCase):
         self.run_name_info_tests()
         self.run_thread_safety_tests()
         self.run_pickle_tests()
-        self.run_scipy_wrapper_tests()
 
     def run_basic_tests(self):
         # Tests for minimal algorithm, and mandatory methods.
@@ -428,7 +427,16 @@ class algorithm_test_case(_ut.TestCase):
         self.assertTrue(a.is_(mbh))
         self.assertTrue(a.extract(mbh).inner_algorithm.is_(_algo))
 
-    def run_scipy_wrapper_tests(self):
+class algorithm_scipy_wrapper_tests(_ut.TestCase):
+    """Test case for the :class:`~pygmo.algorithm` class with the scipy.optimize wrapper."""
+
+    def runTest(self):
+        try:
+            import scipy.version as _sc
+        except ImportError:
+            raise _ut.case.SkipTest("scipy module could not be imported")
+        del _sc
+
         from . import (
             ackley,
             algorithm,

--- a/pygmo/test.py
+++ b/pygmo/test.py
@@ -663,6 +663,11 @@ class free_form_test_case(_ut.TestCase):
             from .core import free_form, topology, ring
         except ImportError:
             return
+        
+        try:
+            import networkx as nx
+        except ImportError:
+            raise _ut.case.SkipTest("networkx module could not be imported")
 
         # Default ctor.
         udt = free_form()
@@ -692,11 +697,6 @@ class free_form_test_case(_ut.TestCase):
         self.assertTrue(len(topo.get_connections(3)[0]) == 0)
         self.assertTrue(len(topo.get_connections(3)[1]) == 0)
         self.assertEqual(topo.get_name(), "Free form")
-
-        try:
-            import networkx as nx
-        except ImportError:
-            return
 
         # Constructor from a valid DiGraph.
         g = nx.DiGraph()
@@ -3429,6 +3429,7 @@ def run_test_suite(level=0):
     suite.addTest(thread_island_torture_test_case())
     suite.addTest(_problem_test.problem_test_case())
     suite.addTest(_algorithm_test.algorithm_test_case())
+    suite.addTest(_algorithm_test.algorithm_scipy_wrapper_tests())
     suite.addTest(_island_test.mp_island_test_case(level))
     suite.addTest(_island_test.ipyparallel_island_test_case(level))
     suite.addTest(golomb_ruler_test_case())


### PR DESCRIPTION
Check whether optional dependencies (i.e., networkx and scipy) are installed before running tests that use them. Fixes #120.

* Moved the SciPy wrapper tests from the main algorithm test class to a dedicated `algorithm_scipy_wrapper_tests` class for better organization. If SciPy is not installed, it only skips the test cases that need SciPy, while the rest of the algorithm_tests are not skipped.

* Moved the handling of the optional `networkx` dependency in `free_form_test_case` to check if the package is present before calling `free_form()`. If the package is not present, it skips the test.